### PR TITLE
Update default.go support easy used session

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-contrib/sessions"
-	"github.com/gin-contrib/sessions/memstore"
+	"github.com/gin-contrib/sessions/cookie"
 	"github.com/gin-gonic/gin"
 )
 
 func InitSession(r *gin.Engine) {
-	store := memstore.NewStore([]byte(Config.AppSecret))
+	store := cookie.NewStore([]byte(Config.AppSecret))
 	opts := sessions.Options{
 		Path:     "/",
 		MaxAge:   1800, // 30 Minutes


### PR DESCRIPTION
Change session store behavior. Switch from memstore to cookie store. Here are several benefits:
1. Memory saving: with data saved in cookie, server saves some memory.
2. Apps with same secrete can keep session alive: compare to memstore, cookie store is more scalable for multiple apps.

Cons:
1. Some frequently changed data are not suitable.
2. Large data are not suitable.

Consider future change to tz-gin-cli which decide which store should be use.