### PR TITLE
Extra

### DIFF
--- a/logger/gin.go
+++ b/logger/gin.go
@@ -18,15 +18,28 @@ func (w ResponseBodyWriter) Write(b []byte) (int, error) {
 	return w.ResponseWriter.Write(b)
 }
 
-func Errorf(ctx *gin.Context, format string, args ...interface{}) {
+func Errorf(format string, args ...interface{}) {
+	GinLogger.Errorf(format, args...)
+}
+func Warnf(format string, args ...interface{}) {
+	GinLogger.Warnf(format, args...)
+}
+func Infof(format string, args ...interface{}) {
+	GinLogger.Infof(format, args...)
+}
+func Debugf(format string, args ...interface{}) {
+	GinLogger.Debugf(format, args...)
+}
+
+func ErrorCtx(ctx *gin.Context, format string, args ...interface{}) {
 	GinLogger.WithContext(ctx).Errorf(format, args...)
 }
-func Warnf(ctx *gin.Context, format string, args ...interface{}) {
+func WarnCtx(ctx *gin.Context, format string, args ...interface{}) {
 	GinLogger.WithContext(ctx).Warnf(format, args...)
 }
-func Infof(ctx *gin.Context, format string, args ...interface{}) {
+func InfoCtx(ctx *gin.Context, format string, args ...interface{}) {
 	GinLogger.WithContext(ctx).Infof(format, args...)
 }
-func Debugf(ctx *gin.Context, format string, args ...interface{}) {
+func DebugCtx(ctx *gin.Context, format string, args ...interface{}) {
 	GinLogger.WithContext(ctx).Debugf(format, args...)
 }

--- a/logger/stderr.go
+++ b/logger/stderr.go
@@ -4,7 +4,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"io"
 	"os"
-	"runtime"
+	"runtime/debug"
 )
 
 type StdWriter struct {
@@ -12,11 +12,14 @@ type StdWriter struct {
 }
 
 func (sw StdWriter) Write(p []byte) (n int, err error) {
-	// Retrieve the file and line number where the error occurred
-	pc, file, line, _ := runtime.Caller(2)
-	func_name := runtime.FuncForPC(pc).Name()
-
-	sw.Logger.Errorf("Find stderr: %s Location: File: %s, Line: %d, Function Name: %s", string(p), file, line, func_name)
+	if GinLogger.Level == logrus.DebugLevel {
+		// Capture the full stack trace
+		stack := debug.Stack()
+		sw.Logger.Errorf("Find stderr: %s \nStack Trace: %s", string(p), stack)
+		return len(p), nil
+	} else {
+		sw.Logger.Errorf("Find stderr: %s", string(p))
+	}
 	return len(p), nil
 }
 

--- a/logger/stderr.go
+++ b/logger/stderr.go
@@ -1,10 +1,10 @@
 package logger
 
 import (
-	"fmt"
 	"github.com/sirupsen/logrus"
 	"io"
 	"os"
+	"runtime"
 )
 
 type StdWriter struct {
@@ -12,7 +12,11 @@ type StdWriter struct {
 }
 
 func (sw StdWriter) Write(p []byte) (n int, err error) {
-	sw.Logger.Error(fmt.Sprintf("stderr: %s", string(p)))
+	// Retrieve the file and line number where the error occurred
+	pc, file, line, _ := runtime.Caller(2)
+	func_name := runtime.FuncForPC(pc).Name()
+
+	sw.Logger.Errorf("Find stderr: %s Location: File: %s, Line: %d, Function Name: %s", string(p), file, line, func_name)
 	return len(p), nil
 }
 

--- a/logger/stderr.go
+++ b/logger/stderr.go
@@ -4,7 +4,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"io"
 	"os"
-	"runtime/debug"
 )
 
 type StdWriter struct {
@@ -12,14 +11,7 @@ type StdWriter struct {
 }
 
 func (sw StdWriter) Write(p []byte) (n int, err error) {
-	if GinLogger.Level == logrus.DebugLevel {
-		// Capture the full stack trace
-		stack := debug.Stack()
-		sw.Logger.Errorf("Find stderr: %s \nStack Trace: %s", string(p), stack)
-		return len(p), nil
-	} else {
-		sw.Logger.Errorf("Find stderr: %s", string(p))
-	}
+	sw.Logger.Errorf("Find stderr: %s", string(p))
 	return len(p), nil
 }
 

--- a/middleware/log.go
+++ b/middleware/log.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"os"
+	"runtime"
 	"runtime/debug"
 	"strings"
 	"template/config"
@@ -128,10 +129,14 @@ func GinRecovery(stack bool) gin.HandlerFunc {
 					c.Abort()
 					return
 				}
+
+				pc, file, line, _ := runtime.Caller(3)
+				func_name := runtime.FuncForPC(pc).Name()
+
 				if stack {
-					logger.GinLogger.Error("panic recovered: ", err, ". Request: ", string(httpRequest), ". Stack: ", string(debug.Stack()))
+					logger.GinLogger.Errorf("panic recovered: %v. Request: %s. File: %s, Line: %d, Function: %s. Stack: %s", err, string(httpRequest), file, line, func_name, string(debug.Stack()))
 				} else {
-					logger.GinLogger.Error("panic recovered: ", err, ". Request: ", string(httpRequest))
+					logger.GinLogger.Errorf("panic recovered: %v. Request: %s. File: %s, Line: %d, Function: %s", err, string(httpRequest), file, line, func_name)
 				}
 				c.AbortWithStatus(http.StatusInternalServerError)
 			}

--- a/middleware/log.go
+++ b/middleware/log.go
@@ -130,6 +130,7 @@ func GinRecovery(stack bool) gin.HandlerFunc {
 					return
 				}
 
+				//deeper stack
 				pc, file, line, _ := runtime.Caller(3)
 				func_name := runtime.FuncForPC(pc).Name()
 

--- a/middleware/log.go
+++ b/middleware/log.go
@@ -78,31 +78,31 @@ func GinLogger() gin.HandlerFunc {
 				switch {
 				case status >= http.StatusInternalServerError:
 					logger.GinLogger.WithFields(logrus.Fields{
-						"\nmethod:":     method,
-						"\nurl:":        path,
-						"\nquery:":      query,
-						"\nclient_ip:":  clientIP,
-						"\nuser_agent:": userAgent,
-						"\nStatus:":     status,
-						"\nduration:":   cost}).Error("Error level log with brief information")
+						"\nmethod":     method,
+						"\nurl":        path,
+						"\nquery":      query,
+						"\nclient_ip":  clientIP,
+						"\nuser_agent": userAgent,
+						"\nStatus":     status,
+						"\nduration":   cost}).Error("Error level log with brief information")
 				case status >= http.StatusBadRequest:
 					logger.GinLogger.WithFields(logrus.Fields{
-						"\nmethod:":     method,
-						"\nurl:":        path,
-						"\nquery:":      query,
-						"\nclient_ip:":  clientIP,
-						"\nuser_agent:": userAgent,
-						"\nstatus:":     status,
-						"\nduration:":   cost}).Warn("Warn level log with brief information")
+						"\nmethod":     method,
+						"\nurl":        path,
+						"\nquery":      query,
+						"\nclient_ip":  clientIP,
+						"\nuser_agent": userAgent,
+						"\nstatus":     status,
+						"\nduration":   cost}).Warn("Warn level log with brief information")
 				default:
 					logger.GinLogger.WithFields(logrus.Fields{
-						"\nmethod:":     method,
-						"\nurl:":        path,
-						"\nquery:":      query,
-						"\nclient_ip:":  clientIP,
-						"\nuser_agent:": userAgent,
-						"\nstatus:":     status,
-						"\nduration:":   cost}).Info("Info level log with brief information")
+						"\nmethod":     method,
+						"\nurl":        path,
+						"\nquery":      query,
+						"\nclient_ip:": clientIP,
+						"\nuser_agent": userAgent,
+						"\nstatus":     status,
+						"\nduration":   cost}).Info("Info level log with brief information")
 				}
 			}
 		}()

--- a/router/router.go
+++ b/router/router.go
@@ -1,8 +1,6 @@
 package router
 
 import (
-	"fmt"
-	"os"
 	"template/middleware"
 
 	"github.com/gin-gonic/gin"
@@ -18,12 +16,5 @@ func InitRouter(r *gin.Engine) {
 		apiRouter.GET("/", ctr.Hello.Hello)
 		apiRouter.GET("/time", ctr.Hello.HelloTime)
 		// end
-	}
-
-	test_r := r.Group("test")
-	{
-		test_r.GET("/v1", func(c *gin.Context) {
-			fmt.Fprintln(os.Stderr, "test")
-		})
 	}
 }

--- a/router/router.go
+++ b/router/router.go
@@ -1,6 +1,8 @@
 package router
 
 import (
+	"fmt"
+	"os"
 	"template/middleware"
 
 	"github.com/gin-gonic/gin"
@@ -16,5 +18,12 @@ func InitRouter(r *gin.Engine) {
 		apiRouter.GET("/", ctr.Hello.Hello)
 		apiRouter.GET("/time", ctr.Hello.HelloTime)
 		// end
+	}
+
+	test_r := r.Group("test")
+	{
+		test_r.GET("/v1", func(c *gin.Context) {
+			fmt.Fprintln(os.Stderr, "test")
+		})
 	}
 }


### PR DESCRIPTION
remove:useless stack print, 
feat,fix:logger format with context,and without

explain
1. golang could not make uninvasive locate error code because it could
not override constructor function
2. By wang jun jie (github: wwwwwanggggg), Not usual when using log fmt
with context, or unnecessary. So write two versions of logger